### PR TITLE
Workflow: Remove old releases

### DIFF
--- a/.github/workflows/cleanup-old.yml
+++ b/.github/workflows/cleanup-old.yml
@@ -18,5 +18,5 @@ jobs:
         shell: bash
         run: |
           RELEASES=`gh release list --repo dsp-testing/codeql-cli-nightlies | sed '1,10d' | cut -f 3`
-          echo $RELEASES | tr '\n' '\0' | xargs -0 -n1 gh release delete --repo dsp-testing/codeql-cli-nightlies --yes
-          echo $RELEASES | sed 's/^/\/repos\/dsp-testing\/codeql-cli-nightlies\/git\/refs\/tags\//' | tr '\n' '\0' | xargs -0 -n1 gh api -X DELETE --silent
+          echo "$RELEASES" | tr '\n' '\0' | xargs -0 -n1 gh release delete --repo dsp-testing/codeql-cli-nightlies --yes
+          echo "$RELEASES" | sed 's/^/\/repos\/dsp-testing\/codeql-cli-nightlies\/git\/refs\/tags\//' | tr '\n' '\0' | xargs -0 -n1 gh api -X DELETE --silent

--- a/.github/workflows/cleanup-old.yml
+++ b/.github/workflows/cleanup-old.yml
@@ -1,0 +1,22 @@
+# Removes old nightly releases
+name: Remove old nightly releases
+on:
+  workflow_dispatch: # for testing changes to this workflow
+
+  # Run nightly at 0500 UTC.
+  schedule:
+    - cron:  '0 5 * * *'
+
+jobs:
+  remove-old-releases:
+    name: Remove old nightly releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove all but last 10 releases
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        shell: bash
+        run: |
+          RELEASES=`gh release list --repo dsp-testing/codeql-cli-nightlies | sed '1,10d' | cut -f 3`
+          echo $RELEASES | tr '\n' '\0' | xargs -0 -n1 gh release delete --repo dsp-testing/codeql-cli-nightlies --yes
+          echo $RELEASES | sed 's/^/\/repos\/dsp-testing\/codeql-cli-nightlies\/git\/refs\/tags\//' | tr '\n' '\0' | xargs -0 -n1 gh api -X DELETE --silent


### PR DESCRIPTION
Adds a workflow to remove old nightly releases from this repository. Specifically, only the 10 most recent releases are kept.