### PR TITLE
Keep the last 90 nightly builds

### DIFF
--- a/.github/workflows/cleanup-old.yml
+++ b/.github/workflows/cleanup-old.yml
@@ -12,11 +12,11 @@ jobs:
     name: Remove old nightly releases
     runs-on: ubuntu-latest
     steps:
-      - name: Remove all but last 10 releases
+      - name: Remove all but last 90 releases
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         shell: bash
         run: |
-          RELEASES=`gh release list --repo dsp-testing/codeql-cli-nightlies | grep "Pre-release" | sed '1,10d' | cut -f 3`
+          RELEASES=`gh api --paginate repos/dsp-testing/codeql-cli-nightlies/releases --jq 'map(select(.prerelease == true)).[90:].[] | .tag_name'`
           echo "$RELEASES" | awk NF | tr '\n' '\0' | xargs --no-run-if-empty -0 -n1 gh release delete --repo dsp-testing/codeql-cli-nightlies --yes
           echo "$RELEASES" | awk NF | sed 's/^/\/repos\/dsp-testing\/codeql-cli-nightlies\/git\/refs\/tags\//' | tr '\n' '\0' | xargs --no-run-if-empty -0 -n1 gh api -X DELETE --silent

--- a/.github/workflows/cleanup-old.yml
+++ b/.github/workflows/cleanup-old.yml
@@ -17,6 +17,8 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         shell: bash
         run: |
-          RELEASES=`gh api --paginate repos/dsp-testing/codeql-cli-nightlies/releases --jq 'map(select(.prerelease == true)).[90:].[] | .tag_name'`
-          echo "$RELEASES" | awk NF | tr '\n' '\0' | xargs --no-run-if-empty -0 -n1 gh release delete --repo dsp-testing/codeql-cli-nightlies --yes
-          echo "$RELEASES" | awk NF | sed 's/^/\/repos\/dsp-testing\/codeql-cli-nightlies\/git\/refs\/tags\//' | tr '\n' '\0' | xargs --no-run-if-empty -0 -n1 gh api -X DELETE --silent
+          # The GitHub API returns results in reverse chronological order, so `[90:]` captures the
+          # 91st and older releases which we want to delete.
+          RELEASES_TO_DELETE=`gh api --paginate repos/dsp-testing/codeql-cli-nightlies/releases --jq 'map(select(.prerelease == true)).[90:].[] | .tag_name'`
+          echo "$RELEASES_TO_DELETE" | awk NF | tr '\n' '\0' | xargs --no-run-if-empty -0 -n1 gh release delete --repo dsp-testing/codeql-cli-nightlies --yes
+          echo "$RELEASES_TO_DELETE" | awk NF | sed 's/^/\/repos\/dsp-testing\/codeql-cli-nightlies\/git\/refs\/tags\//' | tr '\n' '\0' | xargs --no-run-if-empty -0 -n1 gh api -X DELETE --silent


### PR DESCRIPTION
Keep nightly builds around for longer to account for the fact that a certain feature available in a nightly might not be available in a release build for over 10 days in some circumstances.